### PR TITLE
Update imports

### DIFF
--- a/StatelessForm.js
+++ b/StatelessForm.js
@@ -1,4 +1,5 @@
-import React, { Platform, Component, PropTypes, ScrollView, View } from 'react-native'
+import React, { Component, PropTypes } from 'react'
+import { Platform, ScrollView, View } from 'react-native'
 
 export default class StatelessForm extends Component {
   componentDidMount() {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "git+https://github.com/danielweinmann/react-native-stateless-form.git"
   },
+  "engines": {
+    "npm": "^3"
+  },
   "keywords": [
     "react",
     "native",
@@ -26,5 +29,9 @@
   "bugs": {
     "url": "https://github.com/danielweinmann/react-native-stateless-form/issues"
   },
-  "homepage": "https://github.com/danielweinmann/react-native-stateless-form#readme"
+  "homepage": "https://github.com/danielweinmann/react-native-stateless-form#readme",
+  "peerDependencies": {
+    "react": ">=0.14.5",
+    "react-native": ">=0.22"
+  }
 }

--- a/widgets/InlineTextInput.js
+++ b/widgets/InlineTextInput.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, View, Text, TextInput } from 'react-native'
+import React, { Component, PropTypes } from 'react'
+import { View, Text, TextInput } from 'react-native'
 
 export default class InlineTextInput extends Component {
   componentDidMount() {


### PR DESCRIPTION
Updates imports to support the API changes in React Native 0.25

https://github.com/facebook/react-native/releases/tag/v0.25.1

Also adds react and react-native as peerDependencies in the package.json. It's nice to track compatibility, although I did end up adding an npm engine constraint, because npm < 3 handled peerDeps a bit weird. Maybe something you want, maybe not
